### PR TITLE
Fix comments for clarity and grammar in esp_h264_types.h (AUD-7010)

### DIFF
--- a/esp_h264/interface/include/esp_h264_types.h
+++ b/esp_h264/interface/include/esp_h264_types.h
@@ -31,7 +31,7 @@ typedef enum {
 } esp_h264_err_t;
 
 /**
- * @brief  This is unencoded data format
+ * @brief  This is an unencoded data format
  *
  * @note
  *        |-------------------------------|--------------|--------------|--------------|
@@ -58,7 +58,7 @@ typedef enum {
     ESP_H264_RAW_FMT_VUY         = ESP_H264_4CC('Y', '3', '0', '8'),  /*<! VUY */
     ESP_H264_RAW_FMT_UYVY        = ESP_H264_4CC('U', 'Y', 'V', 'Y'),  /*<! UYVY */
     ESP_H264_RAW_FMT_YUYV        = ESP_H264_4CC('Y', 'U', 'Y', 'V'),  /*<! The storage format is YUV422 packet. The data order is Y U Y V... for per line */
-    ESP_H264_RAW_FMT_I420        = ESP_H264_4CC('Y', 'U', '1', '2'),  /*<! The storage format is YUV420 planer（IYUV). The data order is to store all Y first then all U and finally all V */
+    ESP_H264_RAW_FMT_I420        = ESP_H264_4CC('Y', 'U', '1', '2'),  /*<! The storage format is YUV420 planar（IYUV). The data order is to store all Y first, then all U, and finally all V */
     ESP_H264_RAW_FMT_O_UYY_E_VYY = ESP_H264_4CC('O', 'U', 'E', 'V'),  /*<! The storage format is YUV420 packet, the data order is as follows
                                                                            |-------------|-------------------------------|
                                                                            | line number |         data order            |
@@ -80,13 +80,13 @@ typedef enum {
  * @brief  Enumerate video frame type
  */
 typedef enum {
-    ESP_H264_FRAME_TYPE_INVALID = -1,  /*<! Encoder not ready or parameters are invalidate */
+    ESP_H264_FRAME_TYPE_INVALID = -1,  /*<! Encoder not ready or parameters are invalid */
     ESP_H264_FRAME_TYPE_IDR     = 0,   /*<! Instantaneous decoding refresh (IDR) frame
                                             IDR frames are essentially I-frames and use intra-frame prediction.
                                             IDR frames refresh immediately
                                             So IDR frames assume the random access function, a new IDR frame starts,
                                             can recalculate a new GOP start encoding, the player can always play from an IDR frame,
-                                            because after it no frame references the previous frame.
+                                            because after it, no frame references the previous frame.
                                             If there is no IDR frame in a video, the video cannot be accessed randomly. */
     ESP_H264_FRAME_TYPE_I       = 1,   /*<! Intra frame(I frame) type. If output frame type is this,
                                             it means this frame is I-frame excpet IDR frame. */
@@ -98,7 +98,7 @@ typedef enum {
  */
 typedef struct {
     uint8_t *buffer;  /*<! Data buffer */
-    uint32_t len;     /*<! It is buffer length in byte */
+    uint32_t len;     /*<! It is buffer length in bytes */
 } esp_h264_pkt_t;
 
 /**
@@ -134,14 +134,14 @@ typedef struct {
  */
 typedef struct {
     uint32_t bitrate;  /*<! Target bitrate desired
-                            Under normal circumstances, the compression rate of H.264 can reach more than 100 times.
+                            Under normal circumstances, the compression rate of H.264 can exceed 100 times.
                             Therefore, the recommended value is `width` * `height` * `pixel` / `compression ratio`.
                             For network transmission, a smaller value is recommended when the network environment is poor.*/
-    uint8_t  qp_min;   /*<! Mininum of quantization parameter(QP). The range is [0, 51].
-                            The smaller QP, the better video quality and the lower compression rate.*/
-    uint8_t  qp_max;   /*<! Maxinum of quantization parameter(QP). The range is [0, 51].
-                            The smaller QP, the better video quality and the lower compression rate.
-                            It must gather than or equal `qp_min`.*/
+    uint8_t  qp_min;   /*<! Minimum range for quantization parameter(QP). The range is [0, 51].
+                            Smaller QP values reduce the compression ratio, increasing video quality.*/
+    uint8_t  qp_max;   /*<! Maximum range for quantization parameter(QP). The range is [0, 51].
+                            Larger QP values increase compression.
+                            It must be greater than or equal to `qp_min`.*/
 } esp_h264_enc_rc_t;
 
 /**
@@ -152,11 +152,11 @@ typedef struct {
     uint8_t               gop;       /*<! Period of Intra frame
                                           GOP is usually set to the number of frames per second(FPS) output by the encoder,
                                           that is, the FPS, which is generally 25 or 30, but other values can also be set. */
-    uint8_t               fps;       /*<! Maxinum input frames per second
-                                          The higher FPS, the more coherent and realistic the video.
-                                          When FPS is gather than 24, the general video seems coherent.
-                                          When FPS is gather than 30, the game video seems coherent.
-                                          When FPS is gather than 75, increase FPS, the video fluency isn't obvious.*/
+    uint8_t               fps;       /*<! Maximum input frames per second
+                                          The higher the FPS, the more coherent and realistic the video.
+                                          24 FPS is standard for videos to appear coherent.
+                                          30 FPS is standard for video games to appear coherent.
+                                          FPS greater than 75 are generally imperceptible.*/
     esp_h264_resolution_t res;       /*<! Picture resolution */
     esp_h264_enc_rc_t     rc;        /*<! RC parameter */
 } esp_h264_enc_cfg_t;
@@ -167,16 +167,16 @@ typedef struct {
 typedef struct {
     esp_h264_frame_type_t frame_type;  /*<! Frame type */
     esp_h264_pkt_t        raw_data;    /*<! Encoded data stream  */
-    uint32_t              length;      /*<! It's actual length of encoder data in byte */
+    uint32_t              length;      /*<! Actual length of encoder data in bytes */
     uint32_t              dts;         /*<! Decoding time stamp(DTS)
                                             The timestamp of the decoder when decoding relative to SCR(system reference time).
                                             It mainly identifies when the bit stream read into memory begins to be sent to the decoder for decoding.*/
-    uint32_t              pts;         /*<! Presentation time stamp(PTS).The timestamp relative to the SCR when the frame is displayed.
+    uint32_t              pts;         /*<! Presentation time stamp(PTS). The timestamp relative to the SCR when the frame is displayed.
                                             It mainly measures when the decoded video is displayed.
                                             It is time scale. PTS plus time base is actual time.
                                             Commonly time base in TS stream is {1, 90000}.  So PTS uint is 1/90000 second.
                                             If time base is milliseconed, PTS uint is 1 / 1000 second .
-                                            If H.264 encode data have only I-frame and P-frame, the DTS is equal to PTS.
+                                            If H.264 encode data has only I-frame and P-frame, the DTS is equal to PTS.
  */
 } esp_h264_enc_out_frame_t;
 
@@ -194,7 +194,7 @@ typedef struct {
 typedef struct {
     esp_h264_frame_type_t frame_type;  /*<! Frame type */
     uint8_t              *outbuf;      /*<! Decoder data stream  */
-    uint32_t              out_size;    /*<! It's actual length of decoder data in byte */
+    uint32_t              out_size;    /*<! Actual length of decoder data in bytes */
     uint32_t              dts;         /*<! Decoding time stamp(DTS)
                                             The timestamp of the decoder when decoding relative to SCR(system reference time).
                                             It mainly identifies when the bit stream read into memory begins to be sent to the decoder for decoding.*/
@@ -203,13 +203,13 @@ typedef struct {
                                             It is time scale. PTS plus time base is actual time.
                                             Commonly time base in TS stream is {1, 90000}.  So PTS uint is 1/90000 second.
                                             If time base is milliseconed, PTS uint is 1 / 1000 second .
-                                            If H.264 encode data have only I-frame and P-frame, the DTS is equal to PTS. */
+                                            If H.264 encode data has only I-frame and P-frame, the DTS is equal to PTS. */
 } esp_h264_dec_out_frame_t;
 
 /**
  * @brief  Data stream information before encoding
  *
- * @note  User need process the `consume` like following:
+ * @note  User needs to process the `consume` as follows:
  *
  * @code{c}
  *          esp_h264_dec_in_frame_t in_frame = {.raw_data.buffer = buffer, .raw_data.len = len};
@@ -226,7 +226,7 @@ typedef struct {
  */
 typedef struct {
     esp_h264_pkt_t        raw_data;  /*<! Encoded data stream  */
-    uint32_t              consume;   /*<! It's actual consumed data length in byte */
+    uint32_t              consume;   /*<! Actual consumed data length in bytes */
     uint32_t              dts;       /*<! Decoding time stamp(DTS)
                                           The timestamp of the decoder when decoding relative to SCR(system reference time).
                                           It mainly identifies when the bit stream read into memory begins to be sent to the decoder for decoding.*/
@@ -234,8 +234,8 @@ typedef struct {
                                           It mainly measures when the decoded video is displayed.
                                           It is time scale. PTS plus time base is actual time.
                                           Commonly time base in TS stream is {1, 90000}.  So PTS uint is 1/90000 second.
-                                          If time base is milliseconed, PTS uint is 1 / 1000 second .
-                                          If H.264 encode data have only I-frame and P-frame, the DTS is equal to PTS.
+                                          If time base is milliseconed, PTS uint is 1 / 1000 second.
+                                          If H.264 encode data has only I-frame and P-frame, the DTS is equal to PTS.
  */
 } esp_h264_dec_in_frame_t;
 


### PR DESCRIPTION
Corrected grammar and spelling mistakes in comments for additional clarity 
Words like "Maximin" and "gather" rather than greater were confusing.