### PR TITLE
Fix bitrate controller

### DIFF
--- a/esp_h264/hw/src/h264_rc.c
+++ b/esp_h264/hw/src/h264_rc.c
@@ -121,7 +121,7 @@ void esp_h264_rc_end(esp_h264_rc_hd_t rc_hd, uint32_t total_enc_bits, uint32_t f
     } else {
         prc->err_sum += bits_err;
     }
-    prc->eqp = CLIP3((int)prc->err_sum, -5, 5);
+    prc->eqp = CLIP3(-5, 5, (int)prc->err_sum);
     float err_bit_per_frame = 1.0 * prc->ebits / prc->bits_per_frame;
     if (err_bit_per_frame > 0.2) {
         prc->eqp = 1;

--- a/esp_h264/hw/src/h264_rc.c
+++ b/esp_h264/hw/src/h264_rc.c
@@ -22,7 +22,7 @@ typedef struct esp_h264_rc {
     float    mad_frame_pred;
     uint16_t mb_cnt;
     int32_t  ebits;
-    int32_t  err_sum;
+    float    err_sum;
     uint8_t  frame_num;
 } esp_h264_rc_t;
 

--- a/esp_h264/hw/src/h264_rc.c
+++ b/esp_h264/hw/src/h264_rc.c
@@ -22,6 +22,7 @@ typedef struct esp_h264_rc {
     float    mad_frame_pred;
     uint16_t mb_cnt;
     int32_t  ebits;
+    int32_t  ebits_sat_clip;
     float    err_sum;
     uint8_t  frame_num;
 } esp_h264_rc_t;
@@ -49,6 +50,9 @@ esp_h264_rc_hd_t esp_h264_enc_hw_rc_new(uint8_t qp_max, uint8_t qp_min, uint32_t
     prc->qp_min = qp_min;
     prc->qpm = (qp_max + qp_min) >> 1;
     prc->bits_per_frame = bitrate / fps;
+    // cap the error to one second of bitrate budget.
+    // this avoids overcompensating for too long after recovery
+    prc->ebits_sat_clip = (int32_t)bitrate;
     prc->mb_cnt = mb_width * mb_height;
     float mad = 8.0 / (init_mad[(53 / (prc->qpm + 1))]);
     for (uint8_t i = 0; i < 4; i++) {
@@ -71,6 +75,7 @@ void esp_h264_enc_hw_rc_set_bt_fps(esp_h264_rc_hd_t rc_hd, uint32_t bitrate, uin
 {
     esp_h264_rc_t *prc = (esp_h264_rc_t *)rc_hd;
     prc->bits_per_frame = bitrate / fps;
+    prc->ebits_sat_clip = (int32_t)bitrate;
 }
 
 void esp_h264_rc_start(esp_h264_rc_hd_t rc_hd, bool is_iframe, uint32_t *rate, uint32_t *pred_mad, uint8_t *qp)
@@ -102,7 +107,9 @@ void esp_h264_rc_end(esp_h264_rc_hd_t rc_hd, uint32_t total_enc_bits, uint32_t f
     float bits_err;
     float mad_cur = 1.0 * frame_mad_sum / prc->mb_cnt;
     prc->qp_average_frame = frame_qp_sum / prc->mb_cnt;
-    prc->ebits += total_enc_bits - prc->bits_per_frame;
+
+    int32_t frame_err = (int32_t)total_enc_bits - (int32_t)prc->bits_per_frame;
+    prc->ebits = CLIP3(-prc->ebits_sat_clip, prc->ebits_sat_clip, prc->ebits + frame_err);
 
     prc->mad[(prc->frame_num & 0x3)] = mad_cur;
     prc->frame_bits_last[(prc->frame_num & 0x3)] = total_enc_bits;


### PR DESCRIPTION
## Description

The current main has a problem where it randomly would get stuck for ~5min periods at MAX_QP. This was completely unacceptable for our usage, so we worked around that by setting MAX_QP=MIN_QP, effectively disabling the adaptative bitrate.

This PR tweaks the bitrate controller by doing three things:
* fix the branch that increases and decreases bitrates by correcting the `CLIP3` argument order error
* prevent the `ebits` accumulator from overflowing, ensuring faster recovery than 5min; and preventing a sign swap from INT_MAX to INT_MIN, which caused the above trashing despite being on budget.
* also use a float accumulator when adding float values. This is more of a cosmetic change and should have minimum impact.

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
